### PR TITLE
Fix repository reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/isaacs/async-hooks-domain.git"
+    "url": "git://github.com/isaacs/async-hook-domain.git"
   },
   "keywords": [
     "async",


### PR DESCRIPTION
I went in for a Github star from [the npm registery page](https://www.npmjs.com/package/async-hook-domain) and got a 404. Pretty sure this would be why?